### PR TITLE
Global context

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,18 @@ interface Params {
    * Works with both `Logger` and `PinoLogger`
    */
   renameContext?: string;
+  /**
+   * Optional parameter to set global properties to result object,
+   * so logs will be like:
+   * {"level":30, ..., ...globalContext }
+   * It can be used with one data base for all microservices logs,
+   * when you have to filter by microservice name, so you can pass name to global context
+   * and it's appear in all of your logs thriugh whole microservice.
+   * Works only with `PinoLogger`.
+   * Has high priority in order with context and data,
+   * so can not be rewritten by them in case of namespacing conflicts.
+   */
+  globalContext?: { [key: string]: string | number | boolean | null };
 }
 ```
 

--- a/__tests__/global-context.spec.ts
+++ b/__tests__/global-context.spec.ts
@@ -1,0 +1,153 @@
+import { NestFactory } from "@nestjs/core";
+import { Module, Controller, Get, Injectable } from "@nestjs/common";
+import MemoryStream = require("memorystream");
+import * as request from "supertest";
+import { PinoLogger, InjectPinoLogger, LoggerModule, Logger } from "../src";
+import { platforms } from "./utils/platforms";
+import { fastifyExtraWait } from "./utils/fastifyExtraWait";
+import { parseLogs } from "./utils/logs";
+import { __resetOutOfContextForTests } from "../src/PinoLogger";
+import { GlobalContext } from "../src/params";
+
+const testCases = [
+  { caseName: "should work" },
+  { caseName: "global context should not be rewritten by data and context" }
+];
+
+describe("register and use global logger context", () => {
+  let stream: MemoryStream;
+  let serviceLogMessage: string;
+  let controllerLogMessage: string;
+  let serviceContext: string;
+  let controllerContext: string;
+  let renameContext: string;
+  let globalContext: GlobalContext;
+  let logs: string;
+
+  beforeEach(async () => {
+    __resetOutOfContextForTests();
+    stream = new MemoryStream();
+    serviceLogMessage = Math.random().toString();
+    controllerLogMessage = Math.random().toString();
+    serviceContext = Math.random().toString();
+    controllerContext = Math.random().toString();
+    globalContext = { microservice: Math.random().toString() };
+    renameContext = "microservice";
+
+    logs = "";
+  });
+
+  for (const PlatformAdapter of platforms) {
+    testCases.forEach(({ caseName }, caseIndex) => {
+      describe(PlatformAdapter.name, () => {
+        it(caseName, async () => {
+          stream.on("data", (chunk: string) => {
+            logs += chunk.toString();
+          });
+
+          @Injectable()
+          class TestService {
+            constructor(private readonly logger: Logger) {}
+            someMethod0() {
+              this.logger.log(serviceLogMessage, serviceContext);
+            }
+            someMethod1() {
+              this.logger.log(serviceLogMessage, serviceContext);
+            }
+          }
+
+          @Controller("/")
+          class TestController {
+            constructor(
+              private readonly service: TestService,
+              @InjectPinoLogger(controllerContext)
+              private readonly logger: PinoLogger
+            ) {}
+            @Get("case0")
+            getCase0() {
+              this.logger.info({ foo: "bar" }, controllerLogMessage);
+              this.logger.info(controllerLogMessage);
+              this.service.someMethod0();
+              return {};
+            }
+
+            @Get("case1")
+            getCase1() {
+              this.logger.info(
+                { microservice: "bar", foo: "bar" },
+                controllerLogMessage
+              );
+              this.logger.info(controllerLogMessage);
+              this.service.someMethod1();
+              return {};
+            }
+          }
+
+          @Module({
+            imports: [
+              LoggerModule.forRoot({
+                pinoHttp: stream,
+                globalContext,
+                renameContext
+              })
+            ],
+            controllers: [TestController],
+            providers: [TestService]
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(
+            TestModule,
+            new PlatformAdapter(),
+            { logger: false }
+          );
+          const server = app.getHttpServer();
+
+          await app.init();
+          await fastifyExtraWait(PlatformAdapter, app);
+
+          await request(server).get(`/case${caseIndex}`);
+
+          await app.close();
+
+          const parsedLogs = parseLogs(logs);
+
+          const serviceLogObject = parsedLogs.find(
+            v =>
+              v.msg === serviceLogMessage &&
+              v.req &&
+              Object.keys(globalContext).length !== 0 &&
+              Object.entries(globalContext).every(
+                ([key, value]) => v[key] === value
+              )
+          );
+
+          expect(serviceLogObject).toBeTruthy();
+
+          const controllerLogObject1 = parsedLogs.find(
+            v =>
+              v.msg === controllerLogMessage &&
+              v.req &&
+              Object.keys(globalContext).length !== 0 &&
+              Object.entries(globalContext).every(
+                ([key, value]) => v[key] === value
+              ) &&
+              (v as any).foo === "bar"
+          );
+          const controllerLogObject2 = parsedLogs.find(
+            v =>
+              v.msg === controllerLogMessage &&
+              v.req &&
+              Object.keys(globalContext).length !== 0 &&
+              Object.entries(globalContext).every(
+                ([key, value]) => v[key] === value
+              ) &&
+              !("foo" in v)
+          );
+          expect(controllerLogObject1).toBeTruthy();
+          expect(controllerLogObject2).toBeTruthy();
+        });
+      });
+    });
+  }
+});

--- a/src/params.ts
+++ b/src/params.ts
@@ -21,7 +21,7 @@ export interface Params {
 }
 
 export interface GlobalContext {
-  [key: string]: string | number;
+  [key: string]: string | number | boolean | null;
 }
 
 export interface LoggerModuleAsyncParams

--- a/src/params.ts
+++ b/src/params.ts
@@ -17,6 +17,11 @@ export interface Params {
   forRoutes?: Parameters<MiddlewareConfigProxy["forRoutes"]>;
   useExisting?: true;
   renameContext?: string;
+  globalContext?: GlobalContext;
+}
+
+export interface GlobalContext {
+  [key: string]: string | number;
 }
 
 export interface LoggerModuleAsyncParams


### PR DESCRIPTION
In the case of using nestjs-pino with microservices, I had to filter logs in elasticsearch by microserviceName and I thought that would be great to have the option to set variable global once and then use it automatically with all logger actions.
I also did that set global context had a higher priority to data and context in the case of namespacing conflicts. E.g. once set global context parameters can not be rewritten by others.