### PR TITLE
Function to get injection token for InjectPinoLogger tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,23 @@ export class MyService {
 }
 ```
 
+#### Testing a class that uses @InjectPinoLogger
+
+This package exposes a getLoggerToken() function that returns a prepared injection token based on the provided context. 
+Using this token, you can easily provide a mock implementation of the logger using any of the standard custom provider techniques, including useClass, useValue, and useFactory.
+
+```ts
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      MyService,
+      {
+        provide: getLoggerToken(MyService.name),
+        useValue: mockLogger,
+      },
+    ],
+  }).compile();
+```
+
 ## Usage as NestJS app logger
 
 According to [official docs](https://docs.nestjs.com/techniques/logger#dependency-injection), loggers with Dependency injection should be set via following construction:

--- a/src/InjectPinoLogger.ts
+++ b/src/InjectPinoLogger.ts
@@ -7,12 +7,12 @@ const decoratedLoggers = new Set<string>();
 
 export function InjectPinoLogger(context = "") {
   decoratedLoggers.add(context);
-  return Inject(`${decoratedTokenPrefix}${context}`);
+  return Inject(getLoggerToken(context));
 }
 
 function createDecoratedLoggerProvider(context: string): Provider<PinoLogger> {
   return {
-    provide: `${decoratedTokenPrefix}${context}`,
+    provide: getLoggerToken(context),
     useFactory: (logger: PinoLogger) => {
       logger.setContext(context);
       return logger;
@@ -25,4 +25,8 @@ export function createProvidersForDecorated(): Array<Provider<PinoLogger>> {
   return [...decoratedLoggers.values()].map(context =>
     createDecoratedLoggerProvider(context)
   );
+}
+
+export function getLoggerToken(context: string): string {
+  return `${decoratedTokenPrefix}${context}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export { LoggerModule } from "./LoggerModule";
 export { Params, LoggerModuleAsyncParams } from "./params";
 export { Logger } from "./Logger";
 export { PinoLogger } from "./PinoLogger";
-export { InjectPinoLogger } from "./InjectPinoLogger";
+export { InjectPinoLogger, getLoggerToken } from "./InjectPinoLogger";


### PR DESCRIPTION
When using the InjectPinoLogger annotation, the only way to override the logger in tests is to manually construct the injection token. This PR introduces an exported function to generate the injection token which can be used in tests. This is the same approach used in the [nestjs/mongoose library ](https://github.com/nestjs/mongoose/blob/8f4b6bab69868be080a48db4a32dc4d8b0b793cd/lib/common/mongoose.utils.ts#L6)