### PR TITLE
fix: passing object to log when used via nestjs Logger

### DIFF
--- a/__tests__/pino.spec.ts
+++ b/__tests__/pino.spec.ts
@@ -1,0 +1,202 @@
+import { NestFactory } from "@nestjs/core";
+import { Module, Controller, Get, Injectable, Logger as NestjsLogger } from "@nestjs/common";
+import MemoryStream = require("memorystream");
+import * as request from "supertest";
+import { Logger, LoggerModule } from "../src";
+import { platforms } from "./utils/platforms";
+import { fastifyExtraWait } from "./utils/fastifyExtraWait";
+import { parseLogs } from "./utils/logs";
+import { __resetOutOfContextForTests } from "../src/PinoLogger";
+import * as pino from 'pino';
+
+const loggerMethods: [keyof Logger, pino.Level][] = [
+  ["verbose", "trace"],
+  ["debug", "debug"],
+  ["log", "info"],
+  ["warn", "warn"],
+  ["error", "error"]
+];
+
+describe("pino logging", () => {
+  beforeEach(() => __resetOutOfContextForTests());
+
+  for (const PlatformAdapter of platforms) {
+    describe(PlatformAdapter.name, () => {
+      for (const useContext of [true, false]) {
+        describe(`usage via @nestjs/common/Logger ${useContext ? 'with' : 'without'} context`, () => {
+          for (const [loggerMethodName, pinoLevel] of loggerMethods) {
+            describe(loggerMethodName, () => {
+              it("logs strings as `msg` field", async () => {
+                const stream = new MemoryStream();
+                const random = Math.random().toString();
+                let logs = "";
+                stream.on("data", (chunk: string) => {
+                  logs += chunk.toString();
+                });
+
+                @Controller("/")
+                class TestController {
+                  logger = new NestjsLogger(useContext ? TestController.name : undefined);
+
+                  @Get("/")
+                  get() {
+                    if (loggerMethodName === 'error') {
+                      this.logger[loggerMethodName](random, 'trace');
+                    } else {
+                      this.logger[loggerMethodName](random);
+                    }
+                    return {};
+                  }
+                }
+
+                @Module({
+                  imports: [LoggerModule.forRoot({pinoHttp: [{level: pinoLevel}, stream]})],
+                  controllers: [TestController]
+                })
+                class TestModule {
+                }
+
+                const app = await NestFactory.create(
+                  TestModule,
+                  new PlatformAdapter(),
+                  {logger: false}
+                );
+                app.useLogger(app.get(Logger));
+                const server = app.getHttpServer();
+
+                await app.init();
+                await fastifyExtraWait(PlatformAdapter, app);
+
+                await request(server).get("/");
+                await app.close();
+
+                const parsedLogs = parseLogs(logs);
+                const logObject = parsedLogs.find(v => v.msg === random);
+                expect(logObject).toBeTruthy();
+                expect(logObject && logObject.context).toBe(useContext ? TestController.name : undefined);
+                if (loggerMethodName === 'error') {
+                  expect(logObject && logObject.trace).toBe('trace');
+                }
+              });
+
+              it("logs object messages to root object", async () => {
+                const stream = new MemoryStream();
+                const random = Math.random().toString();
+                let logs = "";
+                stream.on("data", (chunk: string) => {
+                  logs += chunk.toString();
+                });
+
+                @Controller("/")
+                class TestController {
+                  logger = new NestjsLogger(useContext ? TestController.name : undefined);
+
+                  @Get("/")
+                  get() {
+                    const msgObject = {
+                      msg: random,
+                      additional: 'value'
+                    };
+                    if (loggerMethodName === 'error') {
+                      this.logger[loggerMethodName](msgObject, 'trace');
+                    } else {
+                      this.logger[loggerMethodName](msgObject);
+                    }
+                    return {};
+                  }
+                }
+
+                @Module({
+                  imports: [LoggerModule.forRoot({pinoHttp: [{level: pinoLevel}, stream]})],
+                  controllers: [TestController]
+                })
+                class TestModule {
+                }
+
+                const app = await NestFactory.create(
+                  TestModule,
+                  new PlatformAdapter(),
+                  {logger: false}
+                );
+                app.useLogger(app.get(Logger));
+                const server = app.getHttpServer();
+
+                await app.init();
+                await fastifyExtraWait(PlatformAdapter, app);
+
+                await request(server).get("/");
+                await app.close();
+
+                const parsedLogs = parseLogs(logs);
+                const logObject = parsedLogs.find(v => v.msg === random);
+                expect(logObject).toBeTruthy();
+                expect(logObject && logObject.context).toBe(useContext ? TestController.name : undefined);
+                expect(logObject && logObject.additional).toBe('value');
+                if (loggerMethodName === 'error') {
+                  expect(logObject && logObject.trace).toBe('trace');
+                }
+              });
+
+              it("overrides context with value from message", async () => {
+                const stream = new MemoryStream();
+                const random = Math.random().toString();
+                let logs = "";
+                stream.on("data", (chunk: string) => {
+                  logs += chunk.toString();
+                });
+
+                @Controller("/")
+                class TestController {
+                  logger = new NestjsLogger(useContext ? TestController.name : undefined);
+
+                  @Get("/")
+                  get() {
+                    const msgObject = {
+                      msg: random,
+                      context: 'MyContext'
+                    };
+                    if (loggerMethodName === 'error') {
+                      this.logger[loggerMethodName](msgObject, 'trace');
+                    } else {
+                      this.logger[loggerMethodName](msgObject);
+                    }
+                    return {};
+                  }
+                }
+
+                @Module({
+                  imports: [LoggerModule.forRoot({pinoHttp: [{level: pinoLevel}, stream]})],
+                  controllers: [TestController]
+                })
+                class TestModule {
+                }
+
+                const app = await NestFactory.create(
+                  TestModule,
+                  new PlatformAdapter(),
+                  {logger: false}
+                );
+                app.useLogger(app.get(Logger));
+                const server = app.getHttpServer();
+
+                await app.init();
+                await fastifyExtraWait(PlatformAdapter, app);
+
+                await request(server).get("/");
+                await app.close();
+
+                const parsedLogs = parseLogs(logs);
+                const logObject = parsedLogs.find(v => v.msg === random);
+                expect(logObject).toBeTruthy();
+                expect(logObject && logObject.context).toBe('MyContext');
+                if (loggerMethodName === 'error') {
+                  expect(logObject && logObject.trace).toBe('trace');
+                }
+              });
+            });
+          }
+        });
+      }
+    });
+  }
+});

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -14,47 +14,74 @@ export class Logger implements LoggerService {
     this.contextName = renameContext || "context";
   }
 
-  verbose(message: any, context?: string, ...args: any[]) {
+  verbose(message: any, context?: string, isTimestampEnabled?: boolean, ...args: any[]) {
     if (context) {
-      this.logger.trace({ [this.contextName]: context }, message, ...args);
+      if (typeof message === 'object') {
+        this.logger.trace({[this.contextName]: context, ...message}, ...args);
+      } else {
+        this.logger.trace({[this.contextName]: context}, message, ...args);
+      }
     } else {
       this.logger.trace(message, ...args);
     }
   }
 
-  debug(message: any, context?: string, ...args: any[]) {
+  debug(message: any, context?: string, isTimestampEnabled?: boolean, ...args: any[]) {
     if (context) {
-      this.logger.debug({ [this.contextName]: context }, message, ...args);
+      if (typeof message === 'object') {
+        this.logger.debug({[this.contextName]: context, ...message}, ...args);
+      } else {
+        this.logger.debug({[this.contextName]: context}, message, ...args);
+      }
     } else {
       this.logger.debug(message, ...args);
     }
   }
 
-  log(message: any, context?: string, ...args: any[]) {
+  log(message: any, context?: string, isTimestampEnabled?: boolean, ...args: any[]) {
     if (context) {
-      this.logger.info({ [this.contextName]: context }, message, ...args);
+      if (typeof message === 'object') {
+        this.logger.info({[this.contextName]: context, ...message}, ...args);
+      } else {
+        this.logger.info({[this.contextName]: context}, message, ...args);
+      }
     } else {
       this.logger.info(message, ...args);
     }
   }
 
-  warn(message: any, context?: string, ...args: any[]) {
+  warn(message: any, context?: string, isTimestampEnabled?: boolean, ...args: any[]) {
     if (context) {
-      this.logger.warn({ [this.contextName]: context }, message, ...args);
+      if (typeof message === 'object') {
+        this.logger.warn({[this.contextName]: context, ...message}, ...args);
+      } else {
+        this.logger.warn({[this.contextName]: context}, message, ...args);
+      }
     } else {
       this.logger.warn(message, ...args);
     }
   }
 
-  error(message: any, trace?: string, context?: string, ...args: any[]) {
+  error(message: any, trace?: string, context?: string, isTimestampEnabled?: boolean, ...args: any[]) {
     if (context) {
-      this.logger.error(
-        { [this.contextName]: context, trace },
-        message,
-        ...args
-      );
+      if (typeof message === 'object') {
+        this.logger.error(
+          { [this.contextName]: context, trace, ...message },
+          ...args
+        );
+      } else {
+        this.logger.error(
+          { [this.contextName]: context, trace },
+          message,
+          ...args
+        );
+      }
     } else if (trace) {
-      this.logger.error({ trace }, message, ...args);
+      if (typeof message === 'object') {
+        this.logger.error({trace, ...message}, ...args);
+      } else {
+        this.logger.error({trace}, message, ...args);
+      }
     } else {
       this.logger.error(message, ...args);
     }


### PR DESCRIPTION
Fixes https://github.com/iamolegga/nestjs-pino/issues/353

It took some additional effort compared to what I originally expected, because I found another bug.
When you use nestjs `Logger`, it automatically passes `isTimestampEnabled` to the instance methods as the third argument. See here: https://github.com/nestjs/nest/blob/master/packages/common/services/logger.service.ts#L114.

When I merged message and context objects, this third argument became second, so pino treated it as the message and overrode the `msg` property with it. So `msg` was always `false`. I couldn't think of anything better that simply swallowing the `isTimestampEnabled` argument since it is not quite applicable to `nestjs-pino`.

Before my merging, this third argument was treated as the first format string argument by `pino`, so it was also a bug.

