### PR TITLE
export pino-params provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,52 @@ import { Logger } from "nestjs-pino";
 const app = await NestFactory.create(MyModule, { logger: false });
 app.useLogger(app.get(Logger));
 ```
+## Extend the Logger class
+
+You can extend the Logger class to add your own business logic.
+
+```ts
+// logger.service.ts
+import { Logger, PinoLogger, Params, PARAMS_PROVIDER_TOKEN } from "nestjs-pino";
+
+@Injectable()
+class LoggerService extends Logger() {
+  // regular injecting
+  constructor(
+    logger: PinoLogger,
+    @Inject(PARAMS_PROVIDER_TOKEN) params: Params
+  ) {
+    ...
+  }
+
+  // extended method
+  myMethod(): any {}
+}
+
+import { PinoLogger, Params, PARAMS_PROVIDER_TOKEN } from "nestjs-pino";
+
+@Injectable()
+class LoggerService extends PinoLogger() {
+  // regular injecting
+  constructor(
+    @Inject(PARAMS_PROVIDER_TOKEN) params: Params
+  ) {
+    ...
+  }
+
+  // extended method
+  myMethod(): any {}
+}
+
+
+// logger.module.ts
+@Module({
+  providers: [LoggerService],
+  exports: [LoggerService],
+  imports: [LoggerModule.forRoot()],
+})
+class LoggerModule {}
+```
 
 ## Migrating
 

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -8,7 +8,7 @@ export class Logger implements LoggerService {
   private readonly contextName: string;
 
   constructor(
-    private readonly logger: PinoLogger,
+    protected readonly logger: PinoLogger,
     @Inject(PARAMS_PROVIDER_TOKEN) { renameContext }: Params
   ) {
     this.contextName = renameContext || "context";

--- a/src/LoggerCoreModule.ts
+++ b/src/LoggerCoreModule.ts
@@ -33,7 +33,7 @@ export class LoggerCoreModule implements NestModule {
     return {
       module: LoggerCoreModule,
       providers: [Logger, ...decorated, PinoLogger, paramsProvider],
-      exports: [Logger, ...decorated, PinoLogger]
+      exports: [Logger, ...decorated, PinoLogger, paramsProvider]
     };
   }
 
@@ -58,7 +58,7 @@ export class LoggerCoreModule implements NestModule {
       module: LoggerCoreModule,
       imports: params.imports,
       providers,
-      exports: [Logger, ...decorated, PinoLogger]
+      exports: [Logger, ...decorated, PinoLogger, paramsProvider]
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { Params, LoggerModuleAsyncParams } from "./params";
 export { Logger } from "./Logger";
 export { PinoLogger } from "./PinoLogger";
 export { InjectPinoLogger, getLoggerToken } from "./InjectPinoLogger";
+export { PARAMS_PROVIDER_TOKEN } from './constants'


### PR DESCRIPTION
With this PR we can now do :

```javascript
// logger.service.ts
import { Inject, Injectable } from '@nestjs/common';
import { Logger, Params, PARAMS_PROVIDER_TOKEN, PinoLogger } from 'nestjs-pino';

@Injectable()
export class LoggerService extends Logger {
    private aProperty: string;
    
    constructor(
        pinoLogger: PinoLogger,
        @Inject(PARAMS_PROVIDER_TOKEN) params: Params,
        aProperty: string
    ) {
        super(pinoLogger, params);
        this.aProperty = aProperty
    }

    aMethod(): void {
        ...
    }
}
```
and 

```javascript
// logger.module.ts
import { Module } from "@nestjs/common";
import { LoggerModule  } from "nestjs-pino";
import { LoggerService } from "./logger.service";

@Module({
  exports: [LoggerService],
  providers: [LoggerService],
  imports: [
   LoggerModule.forRoot()
  ],
})
export class LoggerModule {}
```