### PR TITLE
docs(README): remove nest-morgan reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ There are other Nestjs loggers. The key purposes of this module are:
 
 | Logger             | Nest App logger | Logger service | Autobind request data to logs |
 | ------------------ | :-------------: | :------------: | :---------------------------: |
-| nest-morgan        |        -        |       -        |               -               |
 | nest-winston       |        +        |       +        |               -               |
 | nestjs-pino-logger |        +        |       +        |               -               |
 | **nestjs-pino**    |        +        |       +        |               +               |


### PR DESCRIPTION
nest-morgan was deprecated so it should be removed from comparison as it's not relevant

https://www.npmjs.com/package/nest-morgan
https://github.com/mentos1386/nest-morgan#not-maintained