### PR TITLE
Fix wrong configuration example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ import { LoggerModule } from 'nestjs-pino';
           // install 'pino-pretty' package in order to use the following option
           transport: process.env.NODE_ENV !== 'production'
             ? { target: 'pino-pretty' }
-            : {},
+            : undefined,
           useLevelLabels: true,
           // and all the others...
         },


### PR DESCRIPTION
Having `transport: {}` in the configuration causes the following error:
`TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined`

Instead, `undefined` can be used if we don't want to have custom transport.