### PR TITLE
Adding getRequestContext method to PinoLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,24 @@ const app = await NestFactory.create(AppModule);
 app.useGlobalInterceptors(LoggerErrorInterceptor);
 ```
 
+## Get request context from AsyncLocalStorage
+If you want get access to the request context saved in AsyncLocalStorage. <br>
+You should inject PinoLogger and call getRequestContext method:
+```ts
+import { PinoLogger } from "nestjs-pino";
+
+@Controller()
+export class AppController {
+    constructor(private readonly logger: PinoLogger) {}
+    
+    @Get()
+    get(): string {
+        const request = this.logger.getRequestContext();
+        return 'hi';
+    }
+}
+```
+
 ## Migration
 
 ### v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-pino",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1733,7 +1733,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -4518,7 +4519,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-pino",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Pino logger for NestJS",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/PinoLogger.ts
+++ b/src/PinoLogger.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { Injectable, Inject, Scope } from '@nestjs/common';
 import pino from 'pino';
+import { Request } from 'express';
 import { Params, isPassedLogger, PARAMS_PROVIDER_TOKEN } from './params';
 import { storage } from './storage';
 
@@ -138,6 +139,17 @@ export class PinoLogger implements PinoMethods {
     // outOfContext is always set in runtime before starts using
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return storage.getStore()?.logger || outOfContext!;
+  }
+
+  public getRequestContext(): Request {
+    const store = storage.getStore();
+    const requestContext = storage.getStore()?.logger?.bindings()?.req;
+    if (!store || !requestContext) {
+      throw new Error(
+        `${PinoLogger.name}: unable to assign extra fields out of request scope`,
+      );
+    }
+    return requestContext;
   }
 
   public assign(fields: pino.Bindings) {


### PR DESCRIPTION
We use your logger implementation but we have to make a fork due to the inability to extract the request id.
We have an openapi client to communicate between microservices and each microservice have to extract generated request id and put it in axios interceptor to make a Trace-Id header. Raw example:
```
export class AxiosInterceptorService {
    constructor(
        private readonly httpService: HttpService,
        private readonly logger: PinoLogger,
    ) {
        this.httpService.axiosRef.interceptors.request.use((config: AxiosRequestConfig) => {
            config.headers['X-Trace-Id'] = this.logger.getRequestContext().id;
            return config;
        });
    }
}
```
That's why I suggest such changes.