### PR TITLE
Fix LoggerErrorInterceptor example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ By default, `pino-http` exposes `err` property with a stack trace and error deta
 import { LoggerErrorInterceptor } from 'nestjs-pino';
 
 const app = await NestFactory.create(AppModule);
-app.useGlobalInterceptors(LoggerErrorInterceptor);
+app.useGlobalInterceptors(new LoggerErrorInterceptor());
 ```
 
 ## Migration


### PR DESCRIPTION
Putting the class directly gives a TS error that `intercept` is not implemented. I seems it needs an instance.