### PR TITLE
feat: bump to pino@8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: build-lint-test-publish
 on:
   push:
     branches:
-      - "**/*"
+      - '**/*'
 
 jobs:
   build-lint-test-publish:
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install npm v7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install npm v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install npm v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "typescript": "^4.3.5"
       },
       "engines": {
-        "node": ">=12.17.0 || >=13.10.0"
+        "node": ">= 14"
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "27.5.1",
         "memorystream": "^0.3.1",
-        "pino": "^7.5.1",
-        "pino-http": "^7.0.0",
+        "pino": "^8.2.0",
+        "pino-http": "^8.1.1",
         "prettier": "^2.3.2",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
@@ -46,7 +46,7 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0",
-        "pino-http": "^6.4.0 || ^7.0.0"
+        "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2590,23 +2590,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.6.tgz",
-      "integrity": "sha512-Hkq5PhLgtVoW1obkqYH0i4iELctEKixkhWLPTYs55doGUKCASvkjOXOd/pisVeLdO24ZX9D6yymJ/twqpJiG3g==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.30.6",
-        "@typescript-eslint/visitor-keys": "5.30.6"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.30.7",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.7.tgz",
@@ -2651,69 +2634,6 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.6.tgz",
-      "integrity": "sha512-HdnP8HioL1F7CwVmT4RaaMX57RrfqsOMclZc08wGMiDYJBsLGBM7JwXM4cZJmbWLzIR/pXg1kkrBBVpxTOwfUg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.6.tgz",
-      "integrity": "sha512-Z7TgPoeYUm06smfEfYF0RBkpF8csMyVnqQbLYiGgmUSTaSXTP57bt8f0UFXstbGxKIreTwQCujtaH0LY9w9B+A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.30.6",
-        "@typescript-eslint/visitor-keys": "5.30.6",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
@@ -2839,23 +2759,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.6.tgz",
-      "integrity": "sha512-41OiCjdL2mCaSDi2SvYbzFLlqqlm5v1ZW9Ym55wXKL/Rx6OOB1IbuFGo71Fj6Xy90gJDFTlgOS+vbmtGHPTQQA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.30.6",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -3037,6 +2940,18 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -4161,61 +4076,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/duplexify/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/duplexify/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/duplexify/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4253,15 +4113,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -4882,6 +4733,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -5094,9 +4954,9 @@
       "dev": true
     },
     "node_modules/fast-redact": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
-      "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -8313,9 +8173,9 @@
       }
     },
     "node_modules/on-exit-leak-free": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
       "dev": true
     },
     "node_modules/on-finished": {
@@ -8516,54 +8376,66 @@
       }
     },
     "node_modules/pino": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.2.0.tgz",
+      "integrity": "sha512-HS7+vUpOYEJcNZkyb2ujN2sSayXLyz5XEvDZw4vrxlxHDe34qIDiNf2s+0dD/q/eqEubfxwAItYhY6zCNVZBVw==",
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.0.0",
-        "on-exit-leak-free": "^0.2.0",
-        "pino-abstract-transport": "v0.5.0",
-        "pino-std-serializers": "^4.0.0",
-        "process-warning": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.1.0",
-        "safe-stable-stringify": "^2.1.0",
-        "sonic-boom": "^2.2.1",
-        "thread-stream": "^0.15.1"
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.0.0",
+        "thread-stream": "^2.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
       "dev": true,
       "dependencies": {
-        "duplexify": "^4.1.2",
+        "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
       }
     },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
+      "integrity": "sha512-sVisi3+P2lJ2t0BPbpK629j8wRW06yKGJUcaLAGXPAUhyUxVJm7VsCTit1PFgT4JHUDMrGNR+ZjSKpzGaRF3zw==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/pino-http": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-7.1.0.tgz",
-      "integrity": "sha512-p/SqK6VpLP2AawGZEmciboat3TXlXwbvlElquBfht1gLQkMKwKDTDlsXOEOfKjOXX21ZYHFVVO75C1uKESXHxg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-8.1.1.tgz",
+      "integrity": "sha512-9eXwQ48z1WU9nLTNh923/6bzLQF9aT3q8jbB3WY5HP80YMutl2yHtOAvjz+WVpWiSimcN9qeM64oOABa/VMbdQ==",
       "dev": true,
       "dependencies": {
         "fast-url-parser": "^1.1.3",
         "get-caller-file": "^2.0.5",
-        "pino": "^7.5.0",
-        "pino-std-serializers": "^5.0.0",
+        "pino": "^8.0.0",
+        "pino-std-serializers": "^6.0.0",
         "process-warning": "^2.0.0"
       }
     },
     "node_modules/pino-http/node_modules/pino-std-serializers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.1.0.tgz",
-      "integrity": "sha512-BlNiiaqALYzQVLDsyRRfb/s/PjxzO7BjfVJo0P9JQEtr995l0A6RFHVLmPZXaGg3v06AC26dpCixUibpwrbWrA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
       "dev": true
     },
     "node_modules/pino-http/node_modules/process-warning": {
@@ -8579,15 +8451,21 @@
       "dev": true
     },
     "node_modules/pino/node_modules/pino-std-serializers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
+      "dev": true
+    },
+    "node_modules/pino/node_modules/process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
       "dev": true
     },
     "node_modules/pino/node_modules/sonic-boom": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.7.0.tgz",
-      "integrity": "sha512-Ynxp0OGQG91wvDjCbFlRMHbSUmDq7dE/EgDeUJ/j+Q9x1FVkFry20cjLykxRSmlm3QS0B4JYAKE8239XKN4SHQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.0.0.tgz",
+      "integrity": "sha512-p5DiZOZHbJ2ZO5MADczp5qrfOd3W5Vr2vHxfCpe7G4AzPwVOweIjbfgku8wSQUuk+Y5Yuo8W7JqRe6XKmKistg==",
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -9349,12 +9227,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
-    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -9715,9 +9587,9 @@
       "dev": true
     },
     "node_modules/thread-stream": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.0.0.tgz",
+      "integrity": "sha512-tnbzCbIrA4Khq5SJt/Fyz5DlE8pUnPR3//nWv+cqdRktvAl2NuC9O08HHq2Ifa10bhkvHLuzcesNjaH15EgTXA==",
       "dev": true,
       "dependencies": {
         "real-require": "^0.1.0"
@@ -12584,16 +12456,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.6.tgz",
-      "integrity": "sha512-Hkq5PhLgtVoW1obkqYH0i4iELctEKixkhWLPTYs55doGUKCASvkjOXOd/pisVeLdO24ZX9D6yymJ/twqpJiG3g==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.30.6",
-        "@typescript-eslint/visitor-keys": "5.30.6"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.30.7",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.7.tgz",
@@ -12602,44 +12464,6 @@
       "requires": {
         "@typescript-eslint/utils": "5.30.7",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.6.tgz",
-      "integrity": "sha512-HdnP8HioL1F7CwVmT4RaaMX57RrfqsOMclZc08wGMiDYJBsLGBM7JwXM4cZJmbWLzIR/pXg1kkrBBVpxTOwfUg==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.6.tgz",
-      "integrity": "sha512-Z7TgPoeYUm06smfEfYF0RBkpF8csMyVnqQbLYiGgmUSTaSXTP57bt8f0UFXstbGxKIreTwQCujtaH0LY9w9B+A==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.30.6",
-        "@typescript-eslint/visitor-keys": "5.30.6",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
@@ -12730,16 +12554,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.6.tgz",
-      "integrity": "sha512-41OiCjdL2mCaSDi2SvYbzFLlqqlm5v1ZW9Ym55wXKL/Rx6OOB1IbuFGo71Fj6Xy90gJDFTlgOS+vbmtGHPTQQA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.30.6",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -12922,6 +12736,15 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "abstract-logging": {
       "version": "2.0.1",
@@ -13805,46 +13628,6 @@
         }
       }
     },
-    "duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -13874,15 +13657,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "enhanced-resolve": {
       "version": "5.9.3",
@@ -14350,6 +14124,12 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -14522,9 +14302,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
-      "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
       "dev": true
     },
     "fast-safe-stringify": {
@@ -17016,9 +16796,9 @@
       }
     },
     "on-exit-leak-free": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
       "dev": true
     },
     "on-finished": {
@@ -17168,34 +16948,40 @@
       "dev": true
     },
     "pino": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.2.0.tgz",
+      "integrity": "sha512-HS7+vUpOYEJcNZkyb2ujN2sSayXLyz5XEvDZw4vrxlxHDe34qIDiNf2s+0dD/q/eqEubfxwAItYhY6zCNVZBVw==",
       "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.0.0",
-        "on-exit-leak-free": "^0.2.0",
-        "pino-abstract-transport": "v0.5.0",
-        "pino-std-serializers": "^4.0.0",
-        "process-warning": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.1.0",
-        "safe-stable-stringify": "^2.1.0",
-        "sonic-boom": "^2.2.1",
-        "thread-stream": "^0.15.1"
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.0.0",
+        "thread-stream": "^2.0.0"
       },
       "dependencies": {
         "pino-std-serializers": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-          "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+          "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
+          "dev": true
+        },
+        "process-warning": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+          "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
           "dev": true
         },
         "sonic-boom": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.7.0.tgz",
-          "integrity": "sha512-Ynxp0OGQG91wvDjCbFlRMHbSUmDq7dE/EgDeUJ/j+Q9x1FVkFry20cjLykxRSmlm3QS0B4JYAKE8239XKN4SHQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.0.0.tgz",
+          "integrity": "sha512-p5DiZOZHbJ2ZO5MADczp5qrfOd3W5Vr2vHxfCpe7G4AzPwVOweIjbfgku8wSQUuk+Y5Yuo8W7JqRe6XKmKistg==",
           "dev": true,
           "requires": {
             "atomic-sleep": "^1.0.0"
@@ -17204,32 +16990,43 @@
       }
     },
     "pino-abstract-transport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
       "dev": true,
       "requires": {
-        "duplexify": "^4.1.2",
+        "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
+          "integrity": "sha512-sVisi3+P2lJ2t0BPbpK629j8wRW06yKGJUcaLAGXPAUhyUxVJm7VsCTit1PFgT4JHUDMrGNR+ZjSKpzGaRF3zw==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0"
+          }
+        }
       }
     },
     "pino-http": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-7.1.0.tgz",
-      "integrity": "sha512-p/SqK6VpLP2AawGZEmciboat3TXlXwbvlElquBfht1gLQkMKwKDTDlsXOEOfKjOXX21ZYHFVVO75C1uKESXHxg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-8.1.1.tgz",
+      "integrity": "sha512-9eXwQ48z1WU9nLTNh923/6bzLQF9aT3q8jbB3WY5HP80YMutl2yHtOAvjz+WVpWiSimcN9qeM64oOABa/VMbdQ==",
       "dev": true,
       "requires": {
         "fast-url-parser": "^1.1.3",
         "get-caller-file": "^2.0.5",
-        "pino": "^7.5.0",
-        "pino-std-serializers": "^5.0.0",
+        "pino": "^8.0.0",
+        "pino-std-serializers": "^6.0.0",
         "process-warning": "^2.0.0"
       },
       "dependencies": {
         "pino-std-serializers": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.1.0.tgz",
-          "integrity": "sha512-BlNiiaqALYzQVLDsyRRfb/s/PjxzO7BjfVJo0P9JQEtr995l0A6RFHVLmPZXaGg3v06AC26dpCixUibpwrbWrA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+          "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
           "dev": true
         },
         "process-warning": {
@@ -17817,12 +17614,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
-    },
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -18078,9 +17869,9 @@
       "dev": true
     },
     "thread-stream": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.0.0.tgz",
+      "integrity": "sha512-tnbzCbIrA4Khq5SJt/Fyz5DlE8pUnPR3//nWv+cqdRktvAl2NuC9O08HHq2Ifa10bhkvHLuzcesNjaH15EgTXA==",
       "dev": true,
       "requires": {
         "real-require": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">=12.17.0 || >=13.10.0"
+    "node": ">= 14"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "27.5.1",
     "memorystream": "^0.3.1",
-    "pino": "^7.5.1",
-    "pino-http": "^7.0.0",
+    "pino": "^8.2.0",
+    "pino-http": "^8.1.1",
     "prettier": "^2.3.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
@@ -88,6 +88,6 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0",
-    "pino-http": "^6.4.0 || ^7.0.0"
+    "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
As suggested in <https://github.com/iamolegga/nestjs-pino/pull/1024#issuecomment-1188771346>, pino@8 could be supported without nest@9. I'm not sure why this PR #995 failed though. Perhaps some sub deps issues? This PR passed all the tests on my machine. Let's see if this actually works.

- https://github.com/pinojs/pino/releases/tag/v8.0.0
- https://github.com/pinojs/pino-http/releases/tag/v8.0.0

