### PR TITLE
chore: bump peer dep to nest@9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/core": "^8.0.0",
-        "@nestjs/platform-express": "^8.0.0",
-        "@nestjs/platform-fastify": "^8.0.0",
-        "@nestjs/testing": "^8.0.0",
+        "@nestjs/common": "^9.0.5",
+        "@nestjs/core": "^9.0.5",
+        "@nestjs/platform-express": "^9.0.5",
+        "@nestjs/platform-fastify": "^9.0.5",
+        "@nestjs/testing": "^9.0.5",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.0.1",
         "@types/memorystream": "^0.3.0",
@@ -45,7 +45,7 @@
         "node": ">= 14"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
+        "@nestjs/common": "^8.0.0 || ^9.0.5",
         "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
       }
     },
@@ -1092,18 +1092,93 @@
       "dev": true
     },
     "node_modules/@fastify/ajv-compiler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
-      "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.1.2.tgz",
+      "integrity": "sha512-m2nzzQJeuVmeGOB9rnII9sZiY8AZ02a9WMQfMBfK1jxdFnxm3FPYKGbYpPjODj4halNogwpolyugbTNpnDCi0A==",
       "dev": true,
       "dependencies": {
-        "ajv": "^6.12.6"
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
       }
     },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/@fastify/cors": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-8.0.0.tgz",
+      "integrity": "sha512-mB2GsA7aVwq7XG6B2OM1FMpcaiXY69ZbM1h/xDJxLEVu5ITGcs5XYrBIYTMNU2dQtzO6mzXhGd2dEKaCnB7UgQ==",
+      "dev": true,
+      "dependencies": {
+        "fastify-plugin": "^3.0.0",
+        "vary": "^1.1.2"
+      }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.1.0.tgz",
+      "integrity": "sha512-E8Hfdvs1bG6u0N4vN5Nty6JONUfTdOciyD5rn8KnEsLKIenvOVcr210BQR9t34PRkNyjqnMLGk3e0BsaxRdL+g==",
+      "dev": true
+    },
     "node_modules/@fastify/error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-2.0.0.tgz",
-      "integrity": "sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-dPRyT40GiHRzSCll3/Jn2nPe25+E1VXc9tDwRAIKwFCxd5Np5wzgz1tmooWG3sV0qKgrBibihVoCna2ru4SEFg==",
+      "dev": true
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.0.0.tgz",
+      "integrity": "sha512-9pCi6c6tmGt/qfuf2koZQuSIG6ckP9q3mz+JoMmAq9eQ4EtA92sWoK7E0LJUn2FFTS/hp5kag+4+dWsV5ZfcXg==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stringify": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/formbody": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/formbody/-/formbody-7.0.1.tgz",
+      "integrity": "sha512-CY6IfzdtidHbZezyyXv7u9dzmb2Lv92HyOZDqANuFb++5ojsqoqIb8bJz11bSgPK0MDoqww/dH6DxZDMM8N4ng==",
+      "dev": true,
+      "dependencies": {
+        "fastify-plugin": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/middie": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.0.0.tgz",
+      "integrity": "sha512-SsZUzJwRV2IBhko8TNI5gGzUdUp2Xd0XCrU+pBTfsMN8LYGsksDI/Hb3qcUZ2/Kfg6ecbFEeRO4nZmHeFCDpHQ==",
+      "dev": true,
+      "dependencies": {
+        "fastify-plugin": "^3.0.0",
+        "path-to-regexp": "^6.1.0",
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/@fastify/middie/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1790,12 +1865,11 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.7.tgz",
-      "integrity": "sha512-m/YsbcBal+gA5CFrDpqXqsSfylo+DIQrkFY3qhVIltsYRfu8ct8J9pqsTO6OPf3mvqdOpFGrV5sBjoyAzOBvsw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.0.5.tgz",
+      "integrity": "sha512-13mncUq4JDSluI5IGvusDZANUfNYCIyPamxlPXJOLawGp8JjqRLHGn9ppNJp7W9mN/B/SmpvW9NFEYFIrKYj9g==",
       "dev": true,
       "dependencies": {
-        "axios": "0.27.2",
         "iterare": "1.2.1",
         "tslib": "2.4.0",
         "uuid": "8.3.2"
@@ -1830,9 +1904,9 @@
       "dev": true
     },
     "node_modules/@nestjs/core": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.4.7.tgz",
-      "integrity": "sha512-XB9uexHqzr2xkPo6QSiQWJJttyYYLmvQ5My64cFvWFi7Wk2NIus0/xUNInwX3kmFWB6pF1ab5Y2ZBvWdPwGBhw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.5.tgz",
+      "integrity": "sha512-41BBJlsquasVrGeRWNYb74Fwsc+oB5EmKC/hioQJAhGqIw5Kr5AcdEoEFaMKFzNLAPbU6c/nVW8T8CrvtQbQww==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1849,10 +1923,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/microservices": "^8.0.0",
-        "@nestjs/platform-express": "^8.0.0",
-        "@nestjs/websockets": "^8.0.0",
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/microservices": "^9.0.0",
+        "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/websockets": "^9.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
@@ -1875,9 +1949,9 @@
       "dev": true
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.4.7.tgz",
-      "integrity": "sha512-lPE5Ltg2NbQGRQIwXWY+4cNrXhJdycbxFDQ8mNxSIuv+LbrJBIdEB/NONk+LLn9N/8d2+I2LsIETGQrPvsejBg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.0.5.tgz",
+      "integrity": "sha512-I6NiOPfL116cBqEwAEdJc+L1N9iIcmoqWjMJY52Kb5cMV2PUzxebddXPqo2HOs7WQv3OLVg0zIUcgwIntq1CEQ==",
       "dev": true,
       "dependencies": {
         "body-parser": "1.20.0",
@@ -1891,8 +1965,8 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/core": "^8.0.0"
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0"
       }
     },
     "node_modules/@nestjs/platform-express/node_modules/tslib": {
@@ -1902,16 +1976,16 @@
       "dev": true
     },
     "node_modules/@nestjs/platform-fastify": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-8.4.7.tgz",
-      "integrity": "sha512-3miB5AYQMlwTAC6W3HE3UTfsQF5RcCsellIEHhNKWN9jGA3C++zr24nEBzw61+Ca2fOG4+ccg4agtODn53d+UA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-9.0.5.tgz",
+      "integrity": "sha512-vdVV5/F0POFxWMkpnxuA+tTSET3Ltl2zWzz0DTAON52i1dv93DNAv9I6rd7CutSrRMJhOpGCkKbD94MRpw71Pw==",
       "dev": true,
       "dependencies": {
-        "fastify": "3.29.0",
-        "fastify-cors": "6.1.0",
-        "fastify-formbody": "5.3.0",
-        "light-my-request": "5.0.0",
-        "middie": "6.1.0",
+        "@fastify/cors": "8.0.0",
+        "@fastify/formbody": "7.0.1",
+        "@fastify/middie": "8.0.0",
+        "fastify": "4.2.1",
+        "light-my-request": "5.2.0",
         "path-to-regexp": "3.2.0",
         "tslib": "2.4.0"
       },
@@ -1920,42 +1994,18 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/core": "^8.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "@fastify/static": "^6.0.0",
+        "@fastify/view": "^7.0.0",
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/light-my-request": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.0.0.tgz",
-      "integrity": "sha512-0OPHKV+uHgBOnRokzL1LqeMCnSAo5l/rZS7kyB6G1I8qxGCvhXpq1M6WK565Y9A5CSn50l3DVaHnJ5FCdpguZQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.1.0",
-        "cookie": "^0.5.0",
-        "process-warning": "^1.0.0",
-        "set-cookie-parser": "^2.4.1"
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "@fastify/view": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/platform-fastify/node_modules/tslib": {
@@ -1965,9 +2015,9 @@
       "dev": true
     },
     "node_modules/@nestjs/testing": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.4.7.tgz",
-      "integrity": "sha512-aedpeJFicTBeiTCvJWUG45WMMS53f5eu8t2fXsfjsU1t+WdDJqYcZyrlCzA4dL1B7MfbqaTURdvuVVHTmJO8ag==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.5.tgz",
+      "integrity": "sha512-/RwWhOBz0rPZzoMiKXsuyCr8FkQrtMxPUHwS+SFnZBsNa/jb56GswgUD7/UnTATU15sjcv0fFtFT3rlu6KK5Ew==",
       "dev": true,
       "dependencies": {
         "tslib": "2.4.0"
@@ -1977,10 +2027,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/core": "^8.0.0",
-        "@nestjs/microservices": "^8.0.0",
-        "@nestjs/platform-express": "^8.0.0"
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0",
+        "@nestjs/microservices": "^9.0.0",
+        "@nestjs/platform-express": "^9.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/microservices": {
@@ -3085,6 +3135,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -3168,7 +3257,7 @@
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/arg": {
@@ -3256,15 +3345,14 @@
       }
     },
     "node_modules/avvio": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.5.tgz",
-      "integrity": "sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+      "integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
         "debug": "^4.0.0",
-        "fastq": "^1.6.1",
-        "queue-microtask": "^1.1.2"
+        "fastq": "^1.6.1"
       }
     },
     "node_modules/avvio/node_modules/debug": {
@@ -3289,30 +3377,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -4892,12 +4956,6 @@
         }
       ]
     },
-    "node_modules/fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4933,19 +4991,39 @@
       "dev": true
     },
     "node_modules/fast-json-stringify": {
-      "version": "2.7.13",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
-      "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.1.0.tgz",
+      "integrity": "sha512-IybGfbUc1DQgyrp9Myhwlr1Z5vjV37mBkdgcbuvsvUxv5fayG+cHlTQQpXH9nMwUPgp+5Y3RT7QDgx5zJ9NS3A==",
       "dev": true,
       "dependencies": {
-        "ajv": "^6.11.0",
-        "deepmerge": "^4.2.2",
-        "rfdc": "^1.2.0",
-        "string-similarity": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
       }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -4968,6 +5046,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.1.0.tgz",
+      "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA==",
+      "dev": true
+    },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -4984,67 +5068,25 @@
       "dev": true
     },
     "node_modules/fastify": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.0.tgz",
-      "integrity": "sha512-zXSiDTdHJCHcmDrSje1f1RfzTmUTjMtHnPhh6cdokgfHhloQ+gy0Du+KlEjwTbcNC3Djj4GAsBzl6KvfI9Ah2g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.2.1.tgz",
+      "integrity": "sha512-eyAWHN9+8IPTnhvGz+leseASGV/JZ75Y+jXXV7tid4awUjCMInY1gazZXuTD95xUW+Ve5vfgLjQ2i1i0/XJjdw==",
       "dev": true,
       "dependencies": {
-        "@fastify/ajv-compiler": "^1.0.0",
-        "@fastify/error": "^2.0.0",
-        "abstract-logging": "^2.0.0",
-        "avvio": "^7.1.2",
-        "fast-json-stringify": "^2.5.2",
-        "find-my-way": "^4.5.0",
-        "flatstr": "^1.0.12",
-        "light-my-request": "^4.2.0",
-        "pino": "^6.13.0",
-        "process-warning": "^1.0.0",
+        "@fastify/ajv-compiler": "^3.1.1",
+        "@fastify/error": "^3.0.0",
+        "@fastify/fast-json-stringify-compiler": "^4.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.1.3",
+        "find-my-way": "^7.0.0",
+        "light-my-request": "^5.0.0",
+        "pino": "^8.0.0",
+        "process-warning": "^2.0.0",
         "proxy-addr": "^2.0.7",
-        "rfdc": "^1.1.4",
-        "secure-json-parse": "^2.0.0",
-        "semver": "^7.3.2",
-        "tiny-lru": "^8.0.1"
-      }
-    },
-    "node_modules/fastify-cors": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.1.0.tgz",
-      "integrity": "sha512-QBKz32IoY/iuT74CunRY1XOSpjSTIOh9E3FxulXIBhd0D2vdgG0kDvy0eG6HA/88sRfWHeba43LkGEXPz0Rh8g==",
-      "dev": true,
-      "dependencies": {
-        "fastify-cors-deprecated": "npm:fastify-cors@6.0.3",
-        "process-warning": "^1.0.0"
-      }
-    },
-    "node_modules/fastify-cors/node_modules/fastify-cors-deprecated": {
-      "name": "fastify-cors",
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.0.3.tgz",
-      "integrity": "sha512-fMbXubKKyBHHCfSBtsCi3+7VyVRdhJQmGes5gM+eGKkRErCdm0NaYO0ozd31BQBL1ycoTIjbqOZhJo4RTF/Vlg==",
-      "dev": true,
-      "dependencies": {
-        "fastify-plugin": "^3.0.0",
-        "vary": "^1.1.2"
-      }
-    },
-    "node_modules/fastify-formbody": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/fastify-formbody/-/fastify-formbody-5.3.0.tgz",
-      "integrity": "sha512-7cjFV2HE/doojyfTwCLToIFD6Hmbw2jVTbfqZ2lbUZznQWlSXu+MBQgqBU8T2nHcMfqSi9vx6PyX0LwTehuKkg==",
-      "dev": true,
-      "dependencies": {
-        "fastify-formbody-deprecated": "npm:fastify-formbody@5.2.0",
-        "process-warning": "^1.0.0"
-      }
-    },
-    "node_modules/fastify-formbody-deprecated": {
-      "name": "fastify-formbody",
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/fastify-formbody/-/fastify-formbody-5.2.0.tgz",
-      "integrity": "sha512-d8Y5hCL82akPyoFiXh2wYOm3es0pV9jqoPo3pO9OV2cNF0cQx39J5WAVXzCh4MSt9Z2qF4Fy5gHlvlyESwjtvg==",
-      "dev": true,
-      "dependencies": {
-        "fastify-plugin": "^3.0.0"
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "semver": "^7.3.7",
+        "tiny-lru": "^8.0.2"
       }
     },
     "node_modules/fastify-plugin": {
@@ -5052,24 +5094,6 @@
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
       "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA==",
       "dev": true
-    },
-    "node_modules/fastify/node_modules/pino": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
-      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
-      "dev": true,
-      "dependencies": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "process-warning": "^1.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -5132,18 +5156,16 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.5.1.tgz",
-      "integrity": "sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.0.0.tgz",
+      "integrity": "sha512-NHVohYPYRXgj6jxXVRwm4iMQjA2ggJpyewHz7Nq7hvBnHoYJJIyHuxNzs8QLPTLQfoqxZzls2g6Zm79XMbhXjA==",
       "dev": true,
       "dependencies": {
-        "fast-decode-uri-component": "^1.0.1",
         "fast-deep-equal": "^3.1.3",
-        "safe-regex2": "^2.0.0",
-        "semver-store": "^0.3.0"
+        "safe-regex2": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/find-up": {
@@ -5171,37 +5193,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
     "node_modules/flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -7712,38 +7708,15 @@
       }
     },
     "node_modules/light-my-request": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.10.1.tgz",
-      "integrity": "sha512-l+zWk0HXGhGzY7IYTZnYEqIpj3Mpcyk2f8+FkKUyREywvaiWCf2jyQVxpasKRsploY/nVpoqTlxx72CIeQNcIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.2.0.tgz",
+      "integrity": "sha512-U5Dga8U59VKydIAnHt2XvPVyDfaHsDIpoO+/FPrm4Qnn1tHeczNnLrGjI1bko6BFWgFwTXjTiQN6PkohWiwwcA==",
       "dev": true,
       "dependencies": {
-        "ajv": "^8.1.0",
         "cookie": "^0.5.0",
-        "process-warning": "^1.0.0",
+        "process-warning": "^2.0.0",
         "set-cookie-parser": "^2.4.1"
       }
-    },
-    "node_modules/light-my-request/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/light-my-request/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -7903,26 +7876,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/middie": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/middie/-/middie-6.1.0.tgz",
-      "integrity": "sha512-akpWXv9QFJ3mXq26kiej7nI4EiID1zEVLq5dxRbrkESMUNNOdTFJjt7Uk9mkcR7D9oR+6km3l3Oah9uQof+Uig==",
-      "dev": true,
-      "dependencies": {
-        "fastify-plugin": "^3.0.0",
-        "path-to-regexp": "^6.1.0",
-        "reusify": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/middie/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -8438,28 +8391,10 @@
       "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
       "dev": true
     },
-    "node_modules/pino-http/node_modules/process-warning": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
-      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
-      "dev": true
-    },
-    "node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
-      "dev": true
-    },
     "node_modules/pino/node_modules/pino-std-serializers": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
       "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
-      "dev": true
-    },
-    "node_modules/pino/node_modules/process-warning": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
-      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
       "dev": true
     },
     "node_modules/pino/node_modules/sonic-boom": {
@@ -8631,9 +8566,9 @@
       "dev": true
     },
     "node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
       "dev": true
     },
     "node_modules/prompts": {
@@ -9024,12 +8959,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/semver-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
-      "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
-      "dev": true
-    },
     "node_modules/send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
@@ -9086,9 +9015,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz",
+      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w==",
       "dev": true
     },
     "node_modules/setprototypeof": {
@@ -9151,16 +9080,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dev": true,
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
       }
     },
     "node_modules/source-map": {
@@ -9257,12 +9176,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/string-similarity": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
-      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
-      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -11269,19 +11182,94 @@
       }
     },
     "@fastify/ajv-compiler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
-      "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.1.2.tgz",
+      "integrity": "sha512-m2nzzQJeuVmeGOB9rnII9sZiY8AZ02a9WMQfMBfK1jxdFnxm3FPYKGbYpPjODj4halNogwpolyugbTNpnDCi0A==",
       "dev": true,
       "requires": {
-        "ajv": "^6.12.6"
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
-    "@fastify/error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-2.0.0.tgz",
-      "integrity": "sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w==",
+    "@fastify/cors": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-8.0.0.tgz",
+      "integrity": "sha512-mB2GsA7aVwq7XG6B2OM1FMpcaiXY69ZbM1h/xDJxLEVu5ITGcs5XYrBIYTMNU2dQtzO6mzXhGd2dEKaCnB7UgQ==",
+      "dev": true,
+      "requires": {
+        "fastify-plugin": "^3.0.0",
+        "vary": "^1.1.2"
+      }
+    },
+    "@fastify/deepmerge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.1.0.tgz",
+      "integrity": "sha512-E8Hfdvs1bG6u0N4vN5Nty6JONUfTdOciyD5rn8KnEsLKIenvOVcr210BQR9t34PRkNyjqnMLGk3e0BsaxRdL+g==",
       "dev": true
+    },
+    "@fastify/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-dPRyT40GiHRzSCll3/Jn2nPe25+E1VXc9tDwRAIKwFCxd5Np5wzgz1tmooWG3sV0qKgrBibihVoCna2ru4SEFg==",
+      "dev": true
+    },
+    "@fastify/fast-json-stringify-compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.0.0.tgz",
+      "integrity": "sha512-9pCi6c6tmGt/qfuf2koZQuSIG6ckP9q3mz+JoMmAq9eQ4EtA92sWoK7E0LJUn2FFTS/hp5kag+4+dWsV5ZfcXg==",
+      "dev": true,
+      "requires": {
+        "fast-json-stringify": "^5.0.0"
+      }
+    },
+    "@fastify/formbody": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/formbody/-/formbody-7.0.1.tgz",
+      "integrity": "sha512-CY6IfzdtidHbZezyyXv7u9dzmb2Lv92HyOZDqANuFb++5ojsqoqIb8bJz11bSgPK0MDoqww/dH6DxZDMM8N4ng==",
+      "dev": true,
+      "requires": {
+        "fastify-plugin": "^3.0.0"
+      }
+    },
+    "@fastify/middie": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.0.0.tgz",
+      "integrity": "sha512-SsZUzJwRV2IBhko8TNI5gGzUdUp2Xd0XCrU+pBTfsMN8LYGsksDI/Hb3qcUZ2/Kfg6ecbFEeRO4nZmHeFCDpHQ==",
+      "dev": true,
+      "requires": {
+        "fastify-plugin": "^3.0.0",
+        "path-to-regexp": "^6.1.0",
+        "reusify": "^1.0.4"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        }
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -11846,12 +11834,11 @@
       }
     },
     "@nestjs/common": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.7.tgz",
-      "integrity": "sha512-m/YsbcBal+gA5CFrDpqXqsSfylo+DIQrkFY3qhVIltsYRfu8ct8J9pqsTO6OPf3mvqdOpFGrV5sBjoyAzOBvsw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.0.5.tgz",
+      "integrity": "sha512-13mncUq4JDSluI5IGvusDZANUfNYCIyPamxlPXJOLawGp8JjqRLHGn9ppNJp7W9mN/B/SmpvW9NFEYFIrKYj9g==",
       "dev": true,
       "requires": {
-        "axios": "0.27.2",
         "iterare": "1.2.1",
         "tslib": "2.4.0",
         "uuid": "8.3.2"
@@ -11866,9 +11853,9 @@
       }
     },
     "@nestjs/core": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.4.7.tgz",
-      "integrity": "sha512-XB9uexHqzr2xkPo6QSiQWJJttyYYLmvQ5My64cFvWFi7Wk2NIus0/xUNInwX3kmFWB6pF1ab5Y2ZBvWdPwGBhw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.5.tgz",
+      "integrity": "sha512-41BBJlsquasVrGeRWNYb74Fwsc+oB5EmKC/hioQJAhGqIw5Kr5AcdEoEFaMKFzNLAPbU6c/nVW8T8CrvtQbQww==",
       "dev": true,
       "requires": {
         "@nuxtjs/opencollective": "0.3.2",
@@ -11889,9 +11876,9 @@
       }
     },
     "@nestjs/platform-express": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.4.7.tgz",
-      "integrity": "sha512-lPE5Ltg2NbQGRQIwXWY+4cNrXhJdycbxFDQ8mNxSIuv+LbrJBIdEB/NONk+LLn9N/8d2+I2LsIETGQrPvsejBg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.0.5.tgz",
+      "integrity": "sha512-I6NiOPfL116cBqEwAEdJc+L1N9iIcmoqWjMJY52Kb5cMV2PUzxebddXPqo2HOs7WQv3OLVg0zIUcgwIntq1CEQ==",
       "dev": true,
       "requires": {
         "body-parser": "1.20.0",
@@ -11910,50 +11897,20 @@
       }
     },
     "@nestjs/platform-fastify": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-8.4.7.tgz",
-      "integrity": "sha512-3miB5AYQMlwTAC6W3HE3UTfsQF5RcCsellIEHhNKWN9jGA3C++zr24nEBzw61+Ca2fOG4+ccg4agtODn53d+UA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-9.0.5.tgz",
+      "integrity": "sha512-vdVV5/F0POFxWMkpnxuA+tTSET3Ltl2zWzz0DTAON52i1dv93DNAv9I6rd7CutSrRMJhOpGCkKbD94MRpw71Pw==",
       "dev": true,
       "requires": {
-        "fastify": "3.29.0",
-        "fastify-cors": "6.1.0",
-        "fastify-formbody": "5.3.0",
-        "light-my-request": "5.0.0",
-        "middie": "6.1.0",
+        "@fastify/cors": "8.0.0",
+        "@fastify/formbody": "7.0.1",
+        "@fastify/middie": "8.0.0",
+        "fastify": "4.2.1",
+        "light-my-request": "5.2.0",
         "path-to-regexp": "3.2.0",
         "tslib": "2.4.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "light-my-request": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.0.0.tgz",
-          "integrity": "sha512-0OPHKV+uHgBOnRokzL1LqeMCnSAo5l/rZS7kyB6G1I8qxGCvhXpq1M6WK565Y9A5CSn50l3DVaHnJ5FCdpguZQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^8.1.0",
-            "cookie": "^0.5.0",
-            "process-warning": "^1.0.0",
-            "set-cookie-parser": "^2.4.1"
-          }
-        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -11963,9 +11920,9 @@
       }
     },
     "@nestjs/testing": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.4.7.tgz",
-      "integrity": "sha512-aedpeJFicTBeiTCvJWUG45WMMS53f5eu8t2fXsfjsU1t+WdDJqYcZyrlCzA4dL1B7MfbqaTURdvuVVHTmJO8ag==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.5.tgz",
+      "integrity": "sha512-/RwWhOBz0rPZzoMiKXsuyCr8FkQrtMxPUHwS+SFnZBsNa/jb56GswgUD7/UnTATU15sjcv0fFtFT3rlu6KK5Ew==",
       "dev": true,
       "requires": {
         "tslib": "2.4.0"
@@ -12845,6 +12802,35 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -12904,7 +12890,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "arg": {
@@ -12974,15 +12960,14 @@
       "dev": true
     },
     "avvio": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.5.tgz",
-      "integrity": "sha512-AOhBxyLVdpOad3TujtC9kL/9r3HnTkxwQ5ggOsYrvvZP1cCFvzHWJd5XxZDFuTn+IN8vkKSG5SEJrd27vCSbeA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+      "integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "debug": "^4.0.0",
-        "fastq": "^1.6.1",
-        "queue-microtask": "^1.1.2"
+        "fastq": "^1.6.1"
       },
       "dependencies": {
         "debug": {
@@ -12999,29 +12984,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        }
-      }
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
         }
       }
     },
@@ -14246,12 +14208,6 @@
         }
       }
     },
-    "fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -14284,15 +14240,36 @@
       "dev": true
     },
     "fast-json-stringify": {
-      "version": "2.7.13",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.13.tgz",
-      "integrity": "sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.1.0.tgz",
+      "integrity": "sha512-IybGfbUc1DQgyrp9Myhwlr1Z5vjV37mBkdgcbuvsvUxv5fayG+cHlTQQpXH9nMwUPgp+5Y3RT7QDgx5zJ9NS3A==",
       "dev": true,
       "requires": {
-        "ajv": "^6.11.0",
-        "deepmerge": "^4.2.2",
-        "rfdc": "^1.2.0",
-        "string-similarity": "^4.0.1"
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "fast-levenshtein": {
@@ -14313,6 +14290,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
+    "fast-uri": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.1.0.tgz",
+      "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA==",
+      "dev": true
+    },
     "fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -14331,84 +14314,25 @@
       }
     },
     "fastify": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.29.0.tgz",
-      "integrity": "sha512-zXSiDTdHJCHcmDrSje1f1RfzTmUTjMtHnPhh6cdokgfHhloQ+gy0Du+KlEjwTbcNC3Djj4GAsBzl6KvfI9Ah2g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.2.1.tgz",
+      "integrity": "sha512-eyAWHN9+8IPTnhvGz+leseASGV/JZ75Y+jXXV7tid4awUjCMInY1gazZXuTD95xUW+Ve5vfgLjQ2i1i0/XJjdw==",
       "dev": true,
       "requires": {
-        "@fastify/ajv-compiler": "^1.0.0",
-        "@fastify/error": "^2.0.0",
-        "abstract-logging": "^2.0.0",
-        "avvio": "^7.1.2",
-        "fast-json-stringify": "^2.5.2",
-        "find-my-way": "^4.5.0",
-        "flatstr": "^1.0.12",
-        "light-my-request": "^4.2.0",
-        "pino": "^6.13.0",
-        "process-warning": "^1.0.0",
+        "@fastify/ajv-compiler": "^3.1.1",
+        "@fastify/error": "^3.0.0",
+        "@fastify/fast-json-stringify-compiler": "^4.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.1.3",
+        "find-my-way": "^7.0.0",
+        "light-my-request": "^5.0.0",
+        "pino": "^8.0.0",
+        "process-warning": "^2.0.0",
         "proxy-addr": "^2.0.7",
-        "rfdc": "^1.1.4",
-        "secure-json-parse": "^2.0.0",
-        "semver": "^7.3.2",
-        "tiny-lru": "^8.0.1"
-      },
-      "dependencies": {
-        "pino": {
-          "version": "6.14.0",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
-          "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
-          "dev": true,
-          "requires": {
-            "fast-redact": "^3.0.0",
-            "fast-safe-stringify": "^2.0.8",
-            "flatstr": "^1.0.12",
-            "pino-std-serializers": "^3.1.0",
-            "process-warning": "^1.0.0",
-            "quick-format-unescaped": "^4.0.3",
-            "sonic-boom": "^1.0.2"
-          }
-        }
-      }
-    },
-    "fastify-cors": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.1.0.tgz",
-      "integrity": "sha512-QBKz32IoY/iuT74CunRY1XOSpjSTIOh9E3FxulXIBhd0D2vdgG0kDvy0eG6HA/88sRfWHeba43LkGEXPz0Rh8g==",
-      "dev": true,
-      "requires": {
-        "fastify-cors-deprecated": "npm:fastify-cors@6.0.3",
-        "process-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "fastify-cors-deprecated": {
-          "version": "npm:fastify-cors@6.0.3",
-          "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.0.3.tgz",
-          "integrity": "sha512-fMbXubKKyBHHCfSBtsCi3+7VyVRdhJQmGes5gM+eGKkRErCdm0NaYO0ozd31BQBL1ycoTIjbqOZhJo4RTF/Vlg==",
-          "dev": true,
-          "requires": {
-            "fastify-plugin": "^3.0.0",
-            "vary": "^1.1.2"
-          }
-        }
-      }
-    },
-    "fastify-formbody": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/fastify-formbody/-/fastify-formbody-5.3.0.tgz",
-      "integrity": "sha512-7cjFV2HE/doojyfTwCLToIFD6Hmbw2jVTbfqZ2lbUZznQWlSXu+MBQgqBU8T2nHcMfqSi9vx6PyX0LwTehuKkg==",
-      "dev": true,
-      "requires": {
-        "fastify-formbody-deprecated": "npm:fastify-formbody@5.2.0",
-        "process-warning": "^1.0.0"
-      }
-    },
-    "fastify-formbody-deprecated": {
-      "version": "npm:fastify-formbody@5.2.0",
-      "resolved": "https://registry.npmjs.org/fastify-formbody/-/fastify-formbody-5.2.0.tgz",
-      "integrity": "sha512-d8Y5hCL82akPyoFiXh2wYOm3es0pV9jqoPo3pO9OV2cNF0cQx39J5WAVXzCh4MSt9Z2qF4Fy5gHlvlyESwjtvg==",
-      "dev": true,
-      "requires": {
-        "fastify-plugin": "^3.0.0"
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "semver": "^7.3.7",
+        "tiny-lru": "^8.0.2"
       }
     },
     "fastify-plugin": {
@@ -14469,15 +14393,13 @@
       }
     },
     "find-my-way": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.5.1.tgz",
-      "integrity": "sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.0.0.tgz",
+      "integrity": "sha512-NHVohYPYRXgj6jxXVRwm4iMQjA2ggJpyewHz7Nq7hvBnHoYJJIyHuxNzs8QLPTLQfoqxZzls2g6Zm79XMbhXjA==",
       "dev": true,
       "requires": {
-        "fast-decode-uri-component": "^1.0.1",
         "fast-deep-equal": "^3.1.3",
-        "safe-regex2": "^2.0.0",
-        "semver-store": "^0.3.0"
+        "safe-regex2": "^2.0.0"
       }
     },
     "find-up": {
@@ -14499,22 +14421,10 @@
         "rimraf": "^3.0.2"
       }
     },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
-    },
     "flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-      "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "dev": true
     },
     "form-data": {
@@ -16437,35 +16347,14 @@
       }
     },
     "light-my-request": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.10.1.tgz",
-      "integrity": "sha512-l+zWk0HXGhGzY7IYTZnYEqIpj3Mpcyk2f8+FkKUyREywvaiWCf2jyQVxpasKRsploY/nVpoqTlxx72CIeQNcIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.2.0.tgz",
+      "integrity": "sha512-U5Dga8U59VKydIAnHt2XvPVyDfaHsDIpoO+/FPrm4Qnn1tHeczNnLrGjI1bko6BFWgFwTXjTiQN6PkohWiwwcA==",
       "dev": true,
       "requires": {
-        "ajv": "^8.1.0",
         "cookie": "^0.5.0",
-        "process-warning": "^1.0.0",
+        "process-warning": "^2.0.0",
         "set-cookie-parser": "^2.4.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
       }
     },
     "lines-and-columns": {
@@ -16594,25 +16483,6 @@
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
-      }
-    },
-    "middie": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/middie/-/middie-6.1.0.tgz",
-      "integrity": "sha512-akpWXv9QFJ3mXq26kiej7nI4EiID1zEVLq5dxRbrkESMUNNOdTFJjt7Uk9mkcR7D9oR+6km3l3Oah9uQof+Uig==",
-      "dev": true,
-      "requires": {
-        "fastify-plugin": "^3.0.0",
-        "path-to-regexp": "^6.1.0",
-        "reusify": "^1.0.4"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-          "dev": true
-        }
       }
     },
     "mime": {
@@ -16972,12 +16842,6 @@
           "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
           "dev": true
         },
-        "process-warning": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
-          "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
-          "dev": true
-        },
         "sonic-boom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.0.0.tgz",
@@ -17028,20 +16892,8 @@
           "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
           "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==",
           "dev": true
-        },
-        "process-warning": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
-          "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
-          "dev": true
         }
       }
-    },
-    "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
-      "dev": true
     },
     "pirates": {
       "version": "4.0.5",
@@ -17156,9 +17008,9 @@
       "dev": true
     },
     "process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==",
       "dev": true
     },
     "prompts": {
@@ -17440,12 +17292,6 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "semver-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
-      "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
-      "dev": true
-    },
     "send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
@@ -17498,9 +17344,9 @@
       }
     },
     "set-cookie-parser": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz",
+      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w==",
       "dev": true
     },
     "setprototypeof": {
@@ -17552,16 +17398,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
-    },
-    "sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dev": true,
-      "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -17638,12 +17474,6 @@
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
       }
-    },
-    "string-similarity": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
-      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
-      "dev": true
     },
     "string-width": {
       "version": "4.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "node": ">= 14"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.5",
+        "@nestjs/common": "^8.0.0 || ^9.0.0",
         "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "testEnvironment": "node"
   },
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0 || ^9.0.5",
+    "@nestjs/common": "^8.0.0 || ^9.0.0",
     "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "homepage": "https://github.com/iamolegga/nestjs-pino#readme",
   "devDependencies": {
-    "@nestjs/common": "^8.0.0",
-    "@nestjs/core": "^8.0.0",
-    "@nestjs/platform-express": "^8.0.0",
-    "@nestjs/platform-fastify": "^8.0.0",
-    "@nestjs/testing": "^8.0.0",
+    "@nestjs/common": "^9.0.5",
+    "@nestjs/core": "^9.0.5",
+    "@nestjs/platform-express": "^9.0.5",
+    "@nestjs/platform-fastify": "^9.0.5",
+    "@nestjs/testing": "^9.0.5",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.1",
     "@types/memorystream": "^0.3.0",
@@ -87,7 +87,7 @@
     "testEnvironment": "node"
   },
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0",
+    "@nestjs/common": "^8.0.0 || ^9.0.5",
     "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
Good news is that it seems there is no breaking changes for us to support both version 8 and version 9. All tests should be passed.

closes #1023