### PR TITLE
fix: export outOfContext and storage

### DIFF
--- a/src/PinoLogger.ts
+++ b/src/PinoLogger.ts
@@ -26,7 +26,7 @@ type LoggerFn =
   | ((msg: string, ...args: any[]) => void)
   | ((obj: object, msg?: string, ...args: any[]) => void);
 
-let outOfContext: pino.Logger | undefined;
+export let outOfContext: pino.Logger | undefined;
 
 export function __resetOutOfContextForTests() {
   outOfContext = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 export { LoggerModule } from './LoggerModule';
 export { Logger } from './Logger';
-export { PinoLogger } from './PinoLogger';
+export { PinoLogger, outOfContext } from './PinoLogger';
 export { InjectPinoLogger, getLoggerToken } from './InjectPinoLogger';
 export { LoggerErrorInterceptor } from './LoggerErrorInterceptor';
+export { Store, storage } from './storage';
 export {
   Params,
   LoggerModuleAsyncParams,


### PR DESCRIPTION
Export the relevant object so that can reuse `nestjs-pino` in non-http environments.
Need to reuse `outOfContext` to keep the options set in `LoggerModule.forRoot(options)`.

```ts
import { outOfContext, storage as loggerStorage, Store as LoggerStore } from 'nestjs-pino';
import type { Logger as PinoLogger } from 'pino';

...

@On({ event: 'something' })
public async webSocketEvent(): Promise<void> {
  const store = new LoggerStore((<PinoLogger>outOfContext).child({
    foo: 'bar',
    user: 'test',
  }));

  await loggerStorage.run(store, async () => {
    // logic...
    this.logger.log('hello'); // {"foo":"bar","user":"test","msg":"hello" ... }
  });
}
```

This is not a solution to this issue(https://github.com/iamolegga/nestjs-pino/issues/803), but it can be used as a temporary measure.