### PR TITLE
[feat] add useClass support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ export {
   Params,
   LoggerModuleAsyncParams,
   PARAMS_PROVIDER_TOKEN,
+  LoggerModuleOptionsFactory,
 } from './params';

--- a/src/params.ts
+++ b/src/params.ts
@@ -3,6 +3,7 @@ import { Logger, DestinationStream } from 'pino';
 import {
   MiddlewareConfigProxy,
   ModuleMetadata,
+  Type,
 } from '@nestjs/common/interfaces';
 
 export type PassedLogger = { logger: Logger };
@@ -55,9 +56,14 @@ export interface Params {
   renameContext?: string;
 }
 
+export interface LoggerModuleOptionsFactory {
+  createLoggerOptions(): Promise<Params> | Params;
+}
+
 export interface LoggerModuleAsyncParams
   extends Pick<ModuleMetadata, 'imports' | 'providers'> {
-  useFactory: (...args: any[]) => Params | Promise<Params>;
+  useFactory?: (...args: any[]) => Params | Promise<Params>;
+  useClass?: Type<LoggerModuleOptionsFactory>;
   inject?: any[];
 }
 


### PR DESCRIPTION
I find it a bit unattractive to define logger options within the useFactory method. Therefore, I have decided to add useClass support, which provides a cleaner approach for defining logger options with dependency injection.

**Usage of the feature:**

_logger-config.service.ts_
```ts
import { Injectable } from '@nestjs/common';
import { LoggerModuleOptionsFactory, Params } from 'nestjs-pino';

@Injectable()
export class LoggerConfigService implements LoggerModuleOptionsFactory {
  createLoggerOptions(): Params | Promise<Params> {
    return {
      pinoHttp: {
        level: process.env.LOG_LEVEL,
      },
    };
  }
}
```

_app.module.ts_
```ts
import { Module } from '@nestjs/common';
import { LoggerModule } from 'nestjs-pino';
import { LoggerConfigService} from './logger-config.service';

@Module({
  imports: [
    LoggerModule.forRootAsync({
      useClass: LoggerConfigService,
    }),
  ],
})
export class AppModule {}
```



