### PR TITLE
make generic options in params available

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,12 +9,18 @@ jobs:
       fail-fast: false
       matrix:
         nestjs-version:
-          - "8"
-          - "9"
-          - "10"
+          - '8'
+          - '9'
+          - '10'
         nodejs-version:
           - 18
           - 20
+        pino-http-version:
+          - '6.4'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
         include:
           - nestjs-version: 8
             typescript-version: 4
@@ -42,11 +48,12 @@ jobs:
                 @nestjs/testing@${{ matrix.nestjs-version }} \
                 @types/node@${{ matrix.nodejs-version }} \
                 typescript@${{ matrix.typescript-version }} \
+                pino-http@${{ matrix.pino-http-version }}
                 -D
       - run: npm run lint
       - uses: actions/cache@v3
         with:
           path: coverage
-          key: ${{ github.sha }}-${{ matrix.nestjs-version }}-${{ matrix.nodejs-version }}
+          key: ${{ github.sha }}-${{ matrix.nestjs-version }}-${{ matrix.nodejs-version }}-${{ matrix.pino-http-version }}
       - run: npm t
       - run: npm run build

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -48,7 +48,7 @@ jobs:
                 @nestjs/testing@${{ matrix.nestjs-version }} \
                 @types/node@${{ matrix.nodejs-version }} \
                 typescript@${{ matrix.typescript-version }} \
-                pino-http@${{ matrix.pino-http-version }}
+                pino-http@${{ matrix.pino-http-version }} \
                 -D
       - run: npm run lint
       - uses: actions/cache@v3

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -10,15 +10,15 @@ jobs:
     uses: ./.github/workflows/build-lint-test.yml
     secrets: inherit
 
-  publish-alpha:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]'
-    needs:
-      - build-lint-test
-    uses: ./.github/workflows/publish-alpha.yml
-    secrets: inherit
-
-  coverage:
-    needs:
-      - build-lint-test
-    uses: ./.github/workflows/publish-coverage.yml
-    secrets: inherit
+  # publish-alpha:
+  #   if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]'
+  #   needs:
+  #     - build-lint-test
+  #   uses: ./.github/workflows/publish-alpha.yml
+  #   secrets: inherit
+  #
+  # coverage:
+  #   needs:
+  #     - build-lint-test
+  #   uses: ./.github/workflows/publish-coverage.yml
+  #   secrets: inherit

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { IncomingMessage, ServerResponse } from 'http';
-
 import {
   MiddlewareConfigProxy,
   ModuleMetadata,
@@ -10,19 +8,12 @@ import { Options } from 'pino-http';
 
 export type PassedLogger = { logger: Logger };
 
-export interface Params<
-  IM = IncomingMessage,
-  SR = ServerResponse,
-  CustomLevels extends string = never,
-> {
+export interface Params {
   /**
    * Optional parameters for `pino-http` module
    * @see https://github.com/pinojs/pino-http#pinohttpopts-stream
    */
-  pinoHttp?:
-    | Options<IM, SR, CustomLevels>
-    | DestinationStream
-    | [Options, DestinationStream];
+  pinoHttp?: Options | DestinationStream | [Options, DestinationStream];
 
   /**
    * Optional parameter for routing. It should implement interface of

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { IncomingMessage, ServerResponse } from 'http';
+
 import {
   MiddlewareConfigProxy,
   ModuleMetadata,
@@ -8,12 +10,19 @@ import { Options } from 'pino-http';
 
 export type PassedLogger = { logger: Logger };
 
-export interface Params {
+export interface Params<
+  IM = IncomingMessage,
+  SR = ServerResponse,
+  CustomLevels extends string = never,
+> {
   /**
    * Optional parameters for `pino-http` module
    * @see https://github.com/pinojs/pino-http#pinohttpopts-stream
    */
-  pinoHttp?: Options | DestinationStream | [Options, DestinationStream];
+  pinoHttp?:
+    | Options<IM, SR, CustomLevels>
+    | DestinationStream
+    | [Options, DestinationStream];
 
   /**
    * Optional parameter for routing. It should implement interface of


### PR DESCRIPTION
when trying  to use express `Request` and `Response` for `pinoHttp` options, TypeScript argues that they should be of type `IncomingMessage` and `ServerResponse` (the default ones). This make generics for `pinoHttp` available again inside of `Params` type.

Code:
```ts
import { Environment } from 'src/config/environment.enum';
import { stdTimeFunctions } from 'pino';
import { XCorrelationIdHeader } from './headers.const';
import { AppConfigService } from 'src/config/app-config.service';
// import { Params } from '../../../nestjs-pino/src';
import { Params } from 'nestjs-pino';

export function getLoggerConfig(appConfigService: AppConfigService): Params {
  const pinoHttp: Options<Request, Response> = {
    genReqId: (req) => req.headers[XCorrelationIdHeader] || randomUUID(),
    level: appConfigService.env === Environment.PRODUCTION ? 'info' : 'debug',
    formatters: {
      level: (label) => ({ lvl: label.toUpperCase() }),
    },
    serializers: {
      req: (req: Request) => ({ id: req.id }),
    },
    base: undefined,
    timestamp: stdTimeFunctions.isoTime,
    nestedKey: 'payload',
    customReceivedObject: (req: Request, _res, _val) => ({
      url: req.url,
      method: req.method,
      query: req.query,
      params: req.params,
      body: req.body,
    }),
    customReceivedMessage: (_req, _res) => 'new API request',
  };
  // ERROR ON THE NEXT LINE
  return { pinoHttp };
}
```

TS Error:
```
Type 'Options<Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, Response<any, Record<string, any>>, never>' is not assignable to type 'Options<IncomingMessage, ServerResponse<IncomingMessage>, never> | DestinationStream | [...] | undefined'.
     Type 'Options<Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, Response<any, Record<string, any>>, never>' is not assignable to type 'Options<IncomingMessage, ServerResponse<IncomingMessage>, never>'.
       Types of property 'genReqId' are incompatible.
         Type 'GenReqId<Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, Response<any, Record<string, any>>> | undefined' is not assignable to type 'GenReqId<IncomingMessage, ServerResponse<IncomingMessage>> | undefined'.
           Type 'GenReqId<Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, Response<any, Record<string, any>>>' is not assignable to type 'GenReqId<IncomingMessage, ServerResponse<IncomingMessage>>'.
             Type 'IncomingMessage' is missing the following properties from type 'Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>': get, header, accepts, acceptsCharsets, and 32 more. [2322]
```

PRs solution allow to which resolves the issue:
```ts
Params<Request, Response>
```