### PR TITLE
Option to `assign` response logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ class MyService {
 }
 ```
 
-Due to the [limitation](https://github.com/pinojs/pino-http/issues/30) of the underlying `pino-http` `PinoLogger.assign` cannot extend `Request completed` logs.
+By default, this does not extend `Request completed` logs. Set the `assignResponse` parameter to `true` to also enrich response logs automatically emitted by `pino-http`.
 
 ## Change pino params at runtime
 

--- a/__tests__/assign.spec.ts
+++ b/__tests__/assign.spec.ts
@@ -45,11 +45,14 @@ describe('assign', () => {
           controllers: [TestController],
           providers: [TestService],
         })
-          .forRoot()
+          .forRoot({ pinoHttp: { customSuccessMessage: () => 'success' } })
           .run();
 
         const wanted = logs.some((l) => l.msg === msg && l.foo === 'bar');
         expect(wanted).toBeTruthy();
+        const responseLog = logs.find((l) => l.msg === 'success');
+        expect(responseLog).toBeDefined();
+        expect(responseLog).not.toHaveProperty('foo');
       });
 
       it('out of request context', async () => {
@@ -91,6 +94,54 @@ describe('assign', () => {
         const log = logs.find((l) => l.msg === msg);
         expect(log).toBeTruthy();
         expect(log).not.toHaveProperty('foo');
+      });
+
+      it('response log', async () => {
+        const msg = Math.random().toString();
+
+        @Injectable()
+        class TestService {
+          private readonly logger = new Logger(TestService.name);
+
+          test() {
+            this.logger.log(msg);
+            return {};
+          }
+        }
+
+        @Controller('/')
+        class TestController {
+          constructor(
+            private readonly logger: PinoLogger,
+            private readonly service: TestService,
+          ) {}
+
+          @Get()
+          get() {
+            this.logger.assign({ foo: 'bar' });
+            this.logger.assign({ other: 'value' });
+            return this.service.test();
+          }
+        }
+
+        const logs = await new TestCase(new PlatformAdapter(), {
+          controllers: [TestController],
+          providers: [TestService],
+        })
+          .forRoot({
+            assignResponse: true,
+            pinoHttp: { customSuccessMessage: () => 'success' },
+          })
+          .run();
+
+        const hasServiceLog = logs.some(
+          (l) => l.msg === msg && l.foo === 'bar' && l.other === 'value',
+        );
+        expect(hasServiceLog).toBeTruthy();
+        const hasResponseLog = logs.some(
+          (l) => l.msg === 'success' && l.foo === 'bar' && l.other === 'value',
+        );
+        expect(hasResponseLog).toBeTruthy();
       });
     });
   }

--- a/src/PinoLogger.ts
+++ b/src/PinoLogger.ts
@@ -134,6 +134,7 @@ export class PinoLogger implements PinoMethods {
       );
     }
     store.logger = store.logger.child(fields);
+    store.responseLogger?.setBindings(fields);
   }
 
   protected call(method: pino.Level, ...args: Parameters<LoggerFn>) {

--- a/src/params.ts
+++ b/src/params.ts
@@ -54,6 +54,13 @@ export interface Params {
    * {"level":30, ... "RENAME_CONTEXT_VALUE_HERE":"AppController" }
    */
   renameContext?: string;
+
+  /**
+   * Optional parameter to also assign the response logger during calls to
+   * `PinoLogger.assign`. By default, `assign` does not impact response logs
+   * (e.g.`Request completed`).
+   */
+  assignResponse?: boolean;
 }
 
 // for support of nestjs@8 we don't use

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -3,7 +3,10 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { Logger } from 'pino';
 
 export class Store {
-  constructor(public logger: Logger) {}
+  constructor(
+    public logger: Logger,
+    public responseLogger?: Logger,
+  ) {}
 }
 
 export const storage = new AsyncLocalStorage<Store>();


### PR DESCRIPTION
There's been a few issues around not being able to assign response logs, mainly [this one](https://github.com/iamolegga/nestjs-pino/issues/608). The follow up has been to [document this feature as not supported](https://github.com/iamolegga/nestjs-pino?tab=readme-ov-file#assign-extra-fields-for-future-calls).

However I've found a way to assign response logs as well, rather painlessly. This is a proposal to add an option to support that. I've implemented this as an option such that the default behaviour wouldn't change. Also, because this uses `setBinding`, this effectively changes the existing response logger rather than create a child logger (which wouldn't work).

I couldn't find a reason why this solution hadn't been considered, but maybe there are downsides I haven't though of. Feel free to comment on that.

Cheers,