### PR TITLE
Add ability to filter logs based on contexts

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -8,12 +8,14 @@ import { PinoLogger } from './PinoLogger';
 @Injectable()
 export class Logger implements LoggerService {
   private readonly contextName: string;
+  private readonly filteredContexts: string[];
 
   constructor(
     protected readonly logger: PinoLogger,
-    @Inject(PARAMS_PROVIDER_TOKEN) { renameContext }: Params,
+    @Inject(PARAMS_PROVIDER_TOKEN) { renameContext, filteredContexts }: Params,
   ) {
     this.contextName = renameContext || 'context';
+    this.filteredContexts = filteredContexts || [];
   }
 
   verbose(message: any, ...optionalParams: any[]) {
@@ -48,6 +50,11 @@ export class Logger implements LoggerService {
     let params: any[] = [];
     if (optionalParams.length !== 0) {
       objArg[this.contextName] = optionalParams[optionalParams.length - 1];
+      if (
+        this.filteredContexts &&
+        this.filteredContexts.includes(objArg[this.contextName])
+      )
+        return;
       params = optionalParams.slice(0, -1);
     }
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -56,6 +56,16 @@ export interface Params {
   renameContext?: string;
 
   /**
+   * This is an array of contexts that will be filtered out of the logs.
+   * This is specifically useful for filtering out nestjs internal contexts such
+   * as the logs nest spits out on startup.
+   *
+   * Example:
+   * filteredContexts: ['RouterExplorer', 'RoutesResolver', 'InstanceLoader']
+   */
+  filteredContexts?: string[];
+
+  /**
    * Optional parameter to also assign the response logger during calls to
    * `PinoLogger.assign`. By default, `assign` does not impact response logs
    * (e.g.`Request completed`).


### PR DESCRIPTION
For substantially large application, NestJS's start up logs can be incredibly noisy. Nest doesn't provide a clean way to just disable this logs at the `createApplication` layer. This quick change would allow users to just have those logs filtered out completely.

I would also allow for other various use cases where you may want logs for a given context in one environment, but not in another.

Would be happy to expand more on this PR, such as adding tests if this functionality would be something that others wanted to have merged.