### PR TITLE
chore(source-map): disable emit source map

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "removeComments": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "outDir": "./dist",
     "incremental": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Fixes #1861

When I use tsup to build the NestJS app, I got a bunch of errors since the source map was not found.

If you don't plan to include them in the build, is better to just disable the source map generation.