### PR TITLE
chore(package): allow publishing source map files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "node postinstall.js"
   },
   "files": [
-    "*.{js,d.ts}",
+    "*.{js,d.ts,map}",
     "!jest.config.js",
     "!.eslintrc.js"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "./dist",
     "incremental": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Continuation of #2286, Fixes #1861

Allow publish of source maps.