### PR TITLE
docs: warn that a bare LoggerModule import silently doubles request logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ export class MyService {
 }
 ```
 
+> [!WARNING]
+> Register `LoggerModule` **only** via `forRoot(...)` / `forRootAsync(...)`, and
+> **only once**, in the root module. Never add the bare `LoggerModule` class to a
+> feature module's `imports`, not even just to inject `PinoLogger`. Because
+> `LoggerModule` is `@Global()`, both `Logger` and `PinoLogger` are already
+> available everywhere after the single root registration, so you never need to
+> re-import it. A bare import instantiates the module a second time, which
+> registers the `pino-http` middleware **again** and makes every request log
+> **twice**. The failure is completely silent: no compile error, no injection
+> failure, no warning
+> ([#3074](https://github.com/iamolegga/nestjs-pino/issues/3074)).
+
 ### Drop-in replacement: NativeLogger
 
 `NativeLogger` is a **drop-in replacement** for NestJS's built-in `ConsoleLogger`. It produces **identical JSON output** — same field names, same argument handling, same error format — but powered by pino with request context in every log.


### PR DESCRIPTION
## What

Adds a warning to the README that `LoggerModule` must be registered **only** via `forRoot(...)` / `forRootAsync(...)`, and that adding the bare `LoggerModule` class to a feature module's `imports` silently doubles every request log.

## Why

This is a documentation follow-up to #3074.

`LoggerModule` is `@Global()` and registers the `pino-http` middleware in its `configure()` method. When a bare `LoggerModule` is added to a feature module's `imports` (a natural mistake when someone just wants to inject `PinoLogger` there), NestJS instantiates the module a second time. That second instance resolves the globally-exported params provider and registers the `pino-http` middleware **again**, so every request logs twice.

The failure mode is completely silent: no compile error, no injection failure, no warning at boot. It also appears to explain the earlier reports in #1500 and #1790.

Minimal reproduction: https://github.com/m-risto/nestjs-pino-double-log-repro

## Scope

Docs only, no behavior change. The warning is placed right after the `PinoLogger` injection example, which is exactly where a reader is tempted to re-import the module.
